### PR TITLE
SetTextLineTrigger can trigger on empty line

### DIFF
--- a/integration/scripting/triggers_test.go
+++ b/integration/scripting/triggers_test.go
@@ -95,6 +95,7 @@ func TestSetTextLineTrigger_RealIntegration(t *testing.T) {
 
 	script := `
 		settextlinetrigger 1 "echo 'Line trigger activated'" "prompt"
+		settextlinetrigger 1 "echo 'Line trigger activated'" ""
 		echo "Line trigger set"
 	`
 

--- a/internal/proxy/scripting/triggers/manager.go
+++ b/internal/proxy/scripting/triggers/manager.go
@@ -134,7 +134,7 @@ func (m *Manager) ProcessTextLine(line string) (bool, error) {
 	matched := false
 	for _, trigger := range triggers {
 		log.Debug("TEXTLINE TRIGGER CHECKING", "id", trigger.GetID(), "pattern", trigger.GetValue(), "line", line, "active", trigger.IsActive())
-		if trigger.Matches(line) {
+		if trigger.Matches("") || trigger.Matches(line) {
 			log.Info("TEXTLINE TRIGGER FIRED", "id", trigger.GetID(), "pattern", trigger.GetValue(), "line", line)
 			if err := trigger.Execute(m.vm); err != nil {
 				return false, err

--- a/internal/proxy/scripting/vm/commands/triggers.go
+++ b/internal/proxy/scripting/vm/commands/triggers.go
@@ -40,9 +40,6 @@ func cmdSetTextLineTrigger(vm types.VMInterface, params []*types.CommandParam) e
 	if label == "" {
 		return vm.Error("SETTEXTLINETRIGGER requires a non-empty label")
 	}
-	if pattern == "" {
-		return vm.Error("SETTEXTLINETRIGGER requires a non-empty pattern")
-	}
 
 	// Create TextLineTrigger with Pascal-compatible behavior
 	trigger := &types.TextLineTrigger{


### PR DESCRIPTION
based on twxp docs and example scripts I've looked through, it should be possible to configure `setTextLineTrigger` with an empty string to match so that it triggers on every line.

it looks like you [explicitly prevent that](https://github.com/ianxm/twist/blob/main/internal/proxy/scripting/vm/commands/triggers.go#L44) so maybe there's a reason, but if you wanted to support the function as it is described by twxp, here is a small change to allow empty string and have them match every line.