### PR TITLE
Add support for sector and player stats constants

### DIFF
--- a/internal/proxy/scripting/constants/system.go
+++ b/internal/proxy/scripting/constants/system.go
@@ -93,7 +93,7 @@ func (sc *SystemConstants) initializeConstants() {
 	sc.constants["ALPHACENTAURI"] = types.NewNumberValue(2)
 	sc.constants["RYLOS"] = types.NewNumberValue(3)
 
-	// Player Status Constants (will be dynamic in real implementation)
+	// Player Status Constants
 	sc.constants["TURNS"] = types.NewNumberValue(0)
 	sc.constants["CREDITS"] = types.NewNumberValue(0)
 	sc.constants["FIGHTERS"] = types.NewNumberValue(0)
@@ -230,6 +230,8 @@ func (sc *SystemConstants) updateDynamicConstant(name string) {
 	// CURRENTLINE and CURRENTANSILINE are NOT dynamically updated
 	// They are only updated via explicit UpdateCurrentLine() calls from the TWXParser
 	// This ensures triggers see the correct line that was being processed when they fired
+	case "TURNS", "CREDITS", "FIGHTERS", "SHIELDS", "TOTALHOLDS", "OREHOLDS", "ORGHOLDS", "EQUHOLDS", "COLHOLDS", "EMPTYHOLDS":
+		sc.updatePlayerStatsConstants()
 	case "SECTOR.WARPS", "SECTOR.WARPCOUNT", "SECTOR.DENSITY", "SECTOR.NAVHAZ",
 		"SECTOR.EXPLORED", "SECTOR.ANOMALY", "SECTOR.BEACON", "SECTOR.CONSTELLATION":
 		sc.updateSectorConstants()
@@ -305,6 +307,35 @@ func (sc *SystemConstants) updatePortConstants() {
 		sc.constants["PORT.NAME"] = types.NewStringValue("")
 		sc.constants["PORT.CLASS"] = types.NewNumberValue(0)
 	}
+}
+
+// updatePlayerStatsConstants updates player stats such as turns and credits
+func (sc *SystemConstants) updatePlayerStatsConstants() {
+	if sc.gameInterface == nil {
+		return
+	}
+
+	ps, err := sc.gameInterface.GetPlayerStats()
+	if err != nil {
+		log.Error("failed to get player stats", "error", err)
+	} else {
+		log.Info("playerStats", ps)
+	}
+
+	// update constants based on DB
+	sc.constants["TURNS"] = types.NewNumberValue(float64(ps.Turns))
+	sc.constants["CREDITS"] = types.NewNumberValue(float64(ps.Credits))
+	sc.constants["FIGHTERS"] = types.NewNumberValue(float64(ps.Fighters))
+	sc.constants["SHIELDS"] = types.NewNumberValue(float64(ps.Shields))
+	sc.constants["TOTALHOLDS"] = types.NewNumberValue(float64(ps.TotalHolds))
+	sc.constants["OREHOLDS"] = types.NewNumberValue(float64(ps.OreHolds))
+	sc.constants["ORGHOLDS"] = types.NewNumberValue(float64(ps.OrgHolds))
+	sc.constants["EQUHOLDS"] = types.NewNumberValue(float64(ps.EquHolds))
+	sc.constants["COLHOLDS"] = types.NewNumberValue(float64(ps.ColHolds))
+
+	// Calculate empty holds
+	emptyHolds := ps.TotalHolds - (ps.OreHolds + ps.OrgHolds + ps.EquHolds + ps.ColHolds)
+	sc.constants["EMPTYHOLDS"] = types.NewNumberValue(float64(emptyHolds))
 }
 
 // ListConstants returns all available constants

--- a/internal/proxy/scripting/constants/system.go
+++ b/internal/proxy/scripting/constants/system.go
@@ -230,7 +230,11 @@ func (sc *SystemConstants) updateDynamicConstant(name string) {
 	// CURRENTLINE and CURRENTANSILINE are NOT dynamically updated
 	// They are only updated via explicit UpdateCurrentLine() calls from the TWXParser
 	// This ensures triggers see the correct line that was being processed when they fired
-	case "TURNS", "CREDITS", "FIGHTERS", "SHIELDS", "TOTALHOLDS", "OREHOLDS", "ORGHOLDS", "EQUHOLDS", "COLHOLDS", "EMPTYHOLDS":
+	case "TURNS", "CREDITS", "FIGHTERS", "SHIELDS", "TOTALHOLDS", "OREHOLDS", "ORGHOLDS",
+		"EQUHOLDS", "COLHOLDS", "EMPTYHOLDS", "PHOTONS", "ARMIDS", "LIMPETS", "GENTORPS",
+		"TWARPTYPE", "CLOAKS", "BEACONS", "ATOMICS", "CORBOMITE", "EPROBES", "MINEDISR",
+		"PSYCHICPROBE", "PLANETSCANNER", "SCANTYPE", "ALIGNMENT", "EXPERIENCE", "CORP",
+		"SHIPNUMBER", "SHIPCLASS":
 		sc.updatePlayerStatsConstants()
 	case "SECTOR.WARPS", "SECTOR.WARPCOUNT", "SECTOR.DENSITY", "SECTOR.NAVHAZ",
 		"SECTOR.EXPLORED", "SECTOR.ANOMALY", "SECTOR.BEACON", "SECTOR.CONSTELLATION":
@@ -336,6 +340,34 @@ func (sc *SystemConstants) updatePlayerStatsConstants() {
 	// Calculate empty holds
 	emptyHolds := ps.TotalHolds - (ps.OreHolds + ps.OrgHolds + ps.EquHolds + ps.ColHolds)
 	sc.constants["EMPTYHOLDS"] = types.NewNumberValue(float64(emptyHolds))
+
+	sc.constants["PHOTONS"] = types.NewNumberValue(float64(ps.Photons))
+	sc.constants["ARMIDS"] = types.NewNumberValue(float64(ps.Armids))
+	sc.constants["LIMPETS"] = types.NewNumberValue(float64(ps.Limpets))
+	sc.constants["GENTORPS"] = types.NewNumberValue(float64(ps.GenTorps))
+	sc.constants["TWARPTYPE"] = types.NewNumberValue(float64(ps.TwarpType))
+	sc.constants["CLOAKS"] = types.NewNumberValue(float64(ps.Cloaks))
+	sc.constants["BEACONS"] = types.NewNumberValue(float64(ps.Beacons))
+	sc.constants["ATOMICS"] = types.NewNumberValue(float64(ps.Atomics))
+	sc.constants["CORBOMITE"] = types.NewNumberValue(float64(ps.Corbomite))
+	sc.constants["EPROBES"] = types.NewNumberValue(float64(ps.Eprobes))
+	sc.constants["MINEDISR"] = types.NewNumberValue(float64(ps.MineDisr))
+	if ps.PsychicProbe {
+		sc.constants["PSYCHICPROBE"] = types.NewNumberValue(1)
+	} else {
+		sc.constants["PSYCHICPROBE"] = types.NewNumberValue(0)
+	}
+	if ps.PlanetScanner {
+		sc.constants["PLANETSCANNER"] = types.NewNumberValue(1)
+	} else {
+		sc.constants["PLANETSCANNER"] = types.NewNumberValue(0)
+	}
+	sc.constants["SCANTYPE"] = types.NewNumberValue(float64(ps.ScanType))
+	sc.constants["ALIGNMENT"] = types.NewNumberValue(float64(ps.Alignment))
+	sc.constants["EXPERIENCE"] = types.NewNumberValue(float64(ps.Experience))
+	sc.constants["CORP"] = types.NewNumberValue(float64(ps.Corp))
+	sc.constants["SHIPNUMBER"] = types.NewNumberValue(float64(ps.ShipNumber))
+	sc.constants["SHIPCLASS"] = types.NewStringValue(ps.ShipClass)
 }
 
 // ListConstants returns all available constants

--- a/internal/proxy/scripting/integration.go
+++ b/internal/proxy/scripting/integration.go
@@ -3,6 +3,7 @@ package scripting
 import (
 	"fmt"
 	"strings"
+	"twist/internal/api"
 	"twist/internal/log"
 	"twist/internal/proxy/database"
 	"twist/internal/proxy/interfaces"
@@ -180,8 +181,25 @@ func (g *GameAdapter) GetNearestWarps(sector int, count int) ([]int, error) {
 
 // GetCurrentSector implements GameInterface
 func (g *GameAdapter) GetCurrentSector() int {
-	// TODO: Get current sector from game state
-	return 1
+	if g.db == nil {
+		return 1 // Default fallback
+	}
+
+	playerStats, err := g.db.LoadPlayerStats()
+	if err != nil {
+		log.Error("Failed to load player stats for current sector", "error", err)
+		return 1 // Default fallback
+	}
+
+	return playerStats.CurrentSector
+}
+
+// GetPlayerStats returns current player stats from database
+func (g *GameAdapter) GetPlayerStats() (api.PlayerStatsInfo, error) {
+	if g.db == nil {
+		return api.PlayerStatsInfo{}, fmt.Errorf("database not available")
+	}
+	return g.db.GetPlayerStatsInfo()
 }
 
 // GetCurrentPrompt implements GameInterface

--- a/internal/proxy/scripting/parser/lexer.go
+++ b/internal/proxy/scripting/parser/lexer.go
@@ -212,7 +212,7 @@ func (l *Lexer) readString() string {
 func (l *Lexer) readIdentifier() string {
 	var result strings.Builder
 
-	for !l.eof && (unicode.IsLetter(l.ch) || unicode.IsDigit(l.ch) || l.ch == '_') {
+	for !l.eof && (unicode.IsLetter(l.ch) || unicode.IsDigit(l.ch) || l.ch == '_' || l.ch == '.') {
 		result.WriteRune(l.ch)
 		l.nextChar()
 	}
@@ -238,7 +238,7 @@ func (l *Lexer) readVariable() string {
 	result.WriteRune(l.ch) // include the $
 	l.nextChar()
 
-	for !l.eof && (unicode.IsLetter(l.ch) || unicode.IsDigit(l.ch) || l.ch == '_' || l.ch == '.') {
+	for !l.eof && (unicode.IsLetter(l.ch) || unicode.IsDigit(l.ch) || l.ch == '_' || l.ch == '.' || l.ch == '~') {
 		result.WriteRune(l.ch)
 		l.nextChar()
 	}
@@ -258,7 +258,7 @@ func (l *Lexer) readLabel() string {
 		l.nextChar()
 	}
 
-	for !l.eof && (unicode.IsLetter(l.ch) || unicode.IsDigit(l.ch) || l.ch == '_') {
+	for !l.eof && (unicode.IsLetter(l.ch) || unicode.IsDigit(l.ch) || l.ch == '_' || l.ch == '~') {
 		result.WriteRune(l.ch)
 		l.nextChar()
 	}

--- a/internal/proxy/scripting/types/command.go
+++ b/internal/proxy/scripting/types/command.go
@@ -1,5 +1,9 @@
 package types
 
+import (
+	"twist/internal/api"
+)
+
 // ParameterType represents the type of a command parameter
 type ParameterType int
 
@@ -113,6 +117,7 @@ type GameInterface interface {
 	// Current state
 	GetCurrentSector() int
 	GetCurrentPrompt() string
+	GetPlayerStats() (api.PlayerStatsInfo, error)
 
 	// Network
 	SendCommand(cmd string) error

--- a/internal/proxy/scripting/vm/input_test.go
+++ b/internal/proxy/scripting/vm/input_test.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"testing"
+	"twist/internal/api"
 	"twist/internal/proxy/scripting/types"
 )
 
@@ -26,6 +27,7 @@ func (m *MockGameInterface) GetNearestWarps(sector int, count int) ([]int, error
 }
 func (m *MockGameInterface) GetCurrentSector() int    { return 1 }
 func (m *MockGameInterface) GetCurrentPrompt() string { return "" }
+func (m *MockGameInterface) GetPlayerStats() (api.PlayerStatsInfo, error) { return api.PlayerStatsInfo{}, nil }
 func (m *MockGameInterface) GetLastOutput() string    { return "" }
 func (m *MockGameInterface) GetSystemConstants() types.SystemConstantsInterface {
 	return &MockSystemConstants{}

--- a/internal/proxy/scripting/vm/variables.go
+++ b/internal/proxy/scripting/vm/variables.go
@@ -135,7 +135,7 @@ func (vm *VariableManager) Get(name string) *types.Value {
 		// Check if this is a system constant (only if no user variable exists)
 		if vm.gameInterface != nil {
 			if systemConstants := vm.gameInterface.GetSystemConstants(); systemConstants != nil {
-				if constantValue, exists := systemConstants.GetConstant(baseName); exists {
+				if constantValue, exists := systemConstants.GetConstant(name); exists {
 					// Debug logging for CURRENTLINE access
 					if baseName == "CURRENTLINE" {
 						log.Info("VariableManager.Get: CURRENTLINE accessed", "gameInterface", fmt.Sprintf("%p", vm.gameInterface), "systemConstants", fmt.Sprintf("%p", systemConstants), "value", constantValue.String)


### PR DESCRIPTION
This updates sector and player stats constants and makes them available from scripts.

Currently the lexer isn't able to generate constant identifiers with a `.`, and the parser can't look them up since the lookup is done using the `baseName` but the constant name is the full name. Also this updates the player stats constants from the DB.

This also includes `~` in the lexer since many existing TWXP scripts seem to use it as a separator.